### PR TITLE
feat: reusable workflow で他リポジトリから呼び出し可能に

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -1,0 +1,50 @@
+name: Generate Daily Report
+
+on:
+  workflow_call:
+    inputs:
+      date:
+        description: "Target date (YYYY-MM-DD). Defaults to today."
+        required: false
+        type: string
+      github_user:
+        description: "GitHub username. Defaults to the actor."
+        required: false
+        type: string
+    secrets:
+      gh_pat:
+        description: "Personal Access Token with repo scope (for private repo activity)"
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: shun0918/nippo
+          path: .nippo-tool
+
+      - name: Generate report
+        env:
+          GH_TOKEN: ${{ secrets.gh_pat || github.token }}
+          GITHUB_USER: ${{ inputs.github_user || github.actor }}
+        run: |
+          ./.nippo-tool/scripts/generate-report.sh --output ./reports ${{ inputs.date }}
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add reports/
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "docs: add daily report for ${{ inputs.date || 'today' }}"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -19,32 +19,47 @@
 ./scripts/generate-report.sh 2026-02-14
 
 # 出力先を指定（別リポジトリなど）
-./scripts/generate-report.sh --output ~/Code/nippo-mine
+./scripts/generate-report.sh --output /path/to/your-repo/reports
 
 # 組み合わせ
-GITHUB_USER=foo ./scripts/generate-report.sh --output ~/Code/nippo-mine 2026-02-14
+GITHUB_USER=foo ./scripts/generate-report.sh --output /path/to/your-repo/reports 2026-02-14
 ```
 
-### 2リポジトリ構成
+### GitHub Actions (Reusable Workflow)
 
-日報データを private リポジトリで管理する場合の推奨構成:
+日報データを自分のリポジトリ (private 推奨) で管理できます。以下のワークフローをコピーして `.github/workflows/daily-report.yml` として配置してください:
 
-| リポジトリ | 公開 | 用途 |
-|-----------|------|------|
-| `nippo` | public | スクリプト・ワークフロー |
-| `nippo-mine` | private | 日報データの格納 |
+```yaml
+name: Daily Report
 
-```bash
-# ローカル実行例
-cd nippo
-./scripts/generate-report.sh --output ../nippo-mine/reports
+on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Target date (YYYY-MM-DD). Defaults to today."
+        required: false
+        type: string
+      github_user:
+        description: "GitHub username. Defaults to the actor."
+        required: false
+        type: string
+
+jobs:
+  report:
+    uses: shun0918/nippo/.github/workflows/generate-report.yml@main
+    with:
+      date: ${{ inputs.date || '' }}
+      github_user: ${{ inputs.github_user || '' }}
+    secrets:
+      gh_pat: ${{ secrets.GH_PAT }}
 ```
 
-### GitHub Actions
+#### セットアップ手順
 
-`nippo-mine` リポジトリ側のワークフローから実行できます。詳細は `nippo-mine` の README を参照してください。
-
-> **注意:** プライベートリポジトリの活動を取得するには、`repo` スコープを持つ Personal Access Token (PAT) を `GH_PAT` シークレットとして登録してください。
+1. 日報データ用のリポジトリを作成 (private 推奨)
+2. 上記のワークフローファイルを配置
+3. (任意) プライベートリポジトリの活動も取得したい場合は、`repo` スコープを持つ [Personal Access Token](https://github.com/settings/tokens) を `GH_PAT` シークレットとして登録
+4. **Actions** タブから「Daily Report」を手動実行
 
 ## レポート内容
 


### PR DESCRIPTION
## Summary

- `workflow_call` トリガーの reusable workflow を追加
- README を更新: コピペ用のワークフロースニペットを掲載し、特定の private リポジトリへの参照を削除

## Test plan

- [ ] 別リポジトリから `uses: shun0918/nippo/.github/workflows/generate-report.yml@main` で呼び出せることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)