### PR TITLE
docs: add issue template for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: 新しい機能の提案
+title: ""
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        機能の提案をありがとうございます。
+        以下の項目を記入してください。
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: どのような機能か
+      placeholder: |
+        - 実現したいことを箇条書きで記載
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: なぜその機能が必要か
+      placeholder: |
+        - その機能が必要な理由を記載
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: How
+      description: どのように実現するか
+      placeholder: |
+        - 実装方針やアプローチを記載
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- 既存 issue の What/Why/How フォーマットを GitHub Issue Form テンプレートとして追加
- issue 作成時にフォーム形式で入力できるようになる

## Test plan
- [ ] GitHub 上で新規 issue 作成時にテンプレートが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)