### PR TITLE
feat: add composite action for report generation

### DIFF
--- a/.github/actions/generate-report/action.yml
+++ b/.github/actions/generate-report/action.yml
@@ -31,5 +31,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.gh_token }}
         GITHUB_USER: ${{ inputs.github_user }}
+        INPUT_OUTPUT: ${{ inputs.output }}
+        INPUT_DATE: ${{ inputs.date }}
       run: |
-        ./.nippo-tool/scripts/generate-report.sh --output "${{ inputs.output }}" ${{ inputs.date }}
+        ./.nippo-tool/scripts/generate-report.sh --output "$INPUT_OUTPUT" ${INPUT_DATE:+"$INPUT_DATE"}

--- a/.github/actions/generate-report/action.yml
+++ b/.github/actions/generate-report/action.yml
@@ -1,0 +1,35 @@
+name: "Generate Daily Report"
+description: "Generate a daily activity report using nippo"
+
+inputs:
+  date:
+    description: "Target date (YYYY-MM-DD). Defaults to today."
+    required: false
+    default: ""
+  github_user:
+    description: "GitHub username. Defaults to the actor."
+    required: false
+    default: ${{ github.actor }}
+  gh_token:
+    description: "GitHub token with repo scope (for private repo activity)"
+    required: true
+  output:
+    description: "Output directory for reports"
+    required: false
+    default: "./reports"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: shun0918/nippo
+        path: .nippo-tool
+
+    - name: Generate report
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+        GITHUB_USER: ${{ inputs.github_user }}
+      run: |
+        ./.nippo-tool/scripts/generate-report.sh --output "${{ inputs.output }}" ${{ inputs.date }}


### PR DESCRIPTION
## Summary

- レポート生成を Composite Action として提供し、既存 job 内の step として利用可能にする
- 既存の Reusable Workflow (`generate-report.yml`) は変更なし
- commit & push は呼び出し側の責務とし、柔軟な利用を可能にする

## 利用例

```yaml
steps:
  - uses: actions/checkout@v4
  - uses: shun0918/nippo/.github/actions/generate-report@main
    with:
      gh_token: ${{ secrets.GH_PAT }}
  - name: Commit and push
    run: |
      git add reports/
      git commit -m "docs: add daily report" || true
      git push
```

## Test plan

- [ ] `action.yml` の YAML 構文が正しいことを確認
- [ ] inputs / steps が正しく定義されていることを確認
- [ ] 既存の `generate-report.yml` に変更がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)